### PR TITLE
Add Flask app with tests and dockerized nginx reverse proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+pytest_cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["gunicorn", "-b", "0.0.0.0:5000", "hello_app:app"]

--- a/README
+++ b/README
@@ -1,1 +1,23 @@
-##This project was created for test purpses only
+# Flask Hello World
+
+This sample project demonstrates a simple Flask application with tests and an Nginx reverse proxy in front.
+The `/test` endpoint runs the unit tests and returns results in plain text.
+
+
+1. Build and start the stack using Docker Compose:
+
+```bash
+docker-compose up --build
+```
+
+2. Once running, open [http://localhost:8080/](http://localhost:8080/) to see
+   the "Hello, World!" message.
+3. To execute the tests via the web interface, navigate to
+   [http://localhost:8080/test](http://localhost:8080/test).
+
+Alternatively, you can run tests directly with `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest -q
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  app:
+    build: .
+    expose:
+      - "5000"
+  nginx:
+    image: nginx:alpine
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "8080:80"
+    depends_on:
+      - app

--- a/hello_app.py
+++ b/hello_app.py
@@ -1,0 +1,17 @@
+from flask import Flask, Response
+import subprocess
+
+app = Flask(__name__)
+
+@app.route('/')
+def hello():
+    return 'Hello, World!'
+
+@app.route('/test')
+def run_tests():
+    result = subprocess.run(['pytest', '-q'], capture_output=True, text=True)
+    output = result.stdout + result.stderr
+    return Response(output, mimetype='text/plain')
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,8 @@
+server {
+    listen 80;
+    location / {
+        proxy_pass http://app:5000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+pytest
+gunicorn

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,11 @@
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from hello_app import app
+
+
+def test_hello():
+    client = app.test_client()
+    response = client.get('/')
+    assert response.data == b'Hello, World!'


### PR DESCRIPTION
## Summary
- build a simple Flask Hello World server
- add a `/test` endpoint that runs pytest
- create tests for the root endpoint
- include Dockerfile and docker-compose setup using Nginx reverse proxy
- document local development and how to reach tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ec976a6083339a6e4d0241aae554